### PR TITLE
dpdk: Add Firstboot Workaround To KernelArgs

### DIFF
--- a/ansible/templates/osp/tripleo_heat_envs/features/16.2/nfv_dpdk/firstboot_kernel_workaround.yaml
+++ b/ansible/templates/osp/tripleo_heat_envs/features/16.2/nfv_dpdk/firstboot_kernel_workaround.yaml
@@ -1,0 +1,20 @@
+heat_template_version: 2014-10-16
+
+resources:
+  userdata:
+    type: OS::Heat::MultipartMime
+    properties:
+      parts:
+      - config: {get_resource: kernel_workaround}
+
+  # This is a workaround due to TripleO KernelArgs not applied
+  kernel_workaround:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config: |
+        #!/bin/bash
+        grubby --args="default_hugepagesz=1GB hugepagesz=1G hugepages=64 iommu=pt intel_iommu=on tsx=off"
+
+outputs:
+  OS::stack_id:
+    value: {get_resource: userdata}

--- a/ansible/templates/osp/tripleo_heat_envs/features/16.2/nfv_dpdk/nfv_dpdk.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/features/16.2/nfv_dpdk/nfv_dpdk.yaml.j2
@@ -1,4 +1,6 @@
 ---
+resource_registry:
+    OS::TripleO::NodeUserData: firstboot_kernel_workaround.yaml
 parameter_defaults:
 
     # The OVS logical->physical bridge mappings to use.


### PR DESCRIPTION
Adding a firstboot file to apply kernel arguments due to an issue with
TripleO.